### PR TITLE
Add routes root_path(/) to posts#index

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,8 @@
 Rails.application.routes.draw do
+  # ルートパス ｢/｣ にアクセスした時､railsのデフォルト画面ではなく､
+  # スケジュール一覧ページを表示するために､
+  # ルート先をpostsコントローラーのindexアクションに指定する
+  get '/', to: 'posts#index'
+  
   resources :posts
 end


### PR DESCRIPTION
feature/routesブランチで､ルートパス(/)のアクセス先を､railsのデフォルト画面から､スケジュール一覧ページに変更しました｡
developブランチへのマージを申請します｡